### PR TITLE
fix input padding when there's an icon

### DIFF
--- a/src/textfield/index.scss
+++ b/src/textfield/index.scss
@@ -65,11 +65,11 @@
     resize: vertical;
   }
 
-  :where(.textfield--leading-icon) & {
+  :where(.leading-icon) & {
     padding-inline-start: $textfield-icon-input-padding;
   }
 
-  :where(.textfield--trailing-icon) & {
+  :where(.trailing-icon) & {
     padding-inline-end: $textfield-icon-input-padding;
   }
 


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/protomorph/mas-components/draft/features?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=protomorph&repo=mas-components&branch=draft/features">VS Code</a>

<!-- open-in-codesandbox:complete -->


